### PR TITLE
update to v4 per docs: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

### DIFF
--- a/.github/workflows/azure-deploy-action.yaml
+++ b/.github/workflows/azure-deploy-action.yaml
@@ -50,7 +50,7 @@ jobs:
         run: mvn clean install
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: java-app
           path: '${{ github.workspace }}/target/*.jar'


### PR DESCRIPTION
update to remove deprecated upload-artifact v3 => v4 per: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/